### PR TITLE
docs: update demo link to twil.io short link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Messaging Segment Calculator (SMS + RCS)
 
 This repo contains a package for SMS and RCS segment calculations. The package is released as a nodeJS package as well as a browser script.
-A browser demo for this package can be accessed [here](https://twiliodeved.github.io/message-segment-calculator/)
+Want to see it in action? [Try the live Segment Calculator](https://twil.io/iY0Jwws) to see how any message is encoded and how many segments it takes.
 
 ## Usage 
 


### PR DESCRIPTION
## What changed

Updated the browser demo link in the README to use the `twil.io/iY0Jwws` short link, and refreshed the copy to be more inviting.

Before:
> A browser demo for this package can be accessed [here](https://twiliodeved.github.io/message-segment-calculator/)

After:
> Want to see it in action? [Try the live Segment Calculator](https://twil.io/iY0Jwws) to see how any message is encoded and how many segments it takes.

## Why

Updating copy and link to the segment calculator playground.